### PR TITLE
Fix compile error on tasklet.c

### DIFF
--- a/src/tasklet.c
+++ b/src/tasklet.c
@@ -1,5 +1,6 @@
 #include "tasklet.h"
 
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
There is a compile error when compile `tasklet.c`. Below is the error message:
```c
src/tasklet.c: In function ‘wait_list_fini’:
src/tasklet.c:9:47: error: ‘uintptr_t’ undeclared (first use in this function)
    9 | #define pointer_set_bits(p, bits) ((void *) ((uintptr_t)(p) | (bits)))
      |                                               ^~~~~~~~~
src/tasklet.c:286:23: note: in expansion of macro ‘pointer_set_bits’
  286 |             w->head = pointer_set_bits(&cond, 1);
      |                       ^~~~~~~~~~~~~~~~
src/tasklet.c:9:47: note: each undeclared identifier is reported only once for each function it appears in
    9 | #define pointer_set_bits(p, bits) ((void *) ((uintptr_t)(p) | (bits)))
      |                                               ^~~~~~~~~
src/tasklet.c:286:23: note: in expansion of macro ‘pointer_set_bits’
  286 |             w->head = pointer_set_bits(&cond, 1);
      |                       ^~~~~~~~~~~~~~~~
src/tasklet.c: In function ‘tasklet_unwait’:
src/tasklet.c:7:27: error: ‘uintptr_t’ undeclared (first use in this function)
    7 | #define pointer_bits(p) ((uintptr_t)(p) &3)
      |                           ^~~~~~~~~
src/tasklet.c:327:32: note: in expansion of macro ‘pointer_bits’
  327 |         if (!--w->unwaiting && pointer_bits(w->head)) {
      |                                ^~~~~~~~~~~~
make: *** [Makefile:38: src/tasklet.o] Error 1
```
It needs to include header file `<stdint.h>` in `tasklet.c` to fix this error.

My build environment:
Kernel version: 5.3.0-51-generic
OS: Ubuntu 19.10